### PR TITLE
Add lang attribute for html tag

### DIFF
--- a/dist/supporting-files/base.html.js
+++ b/dist/supporting-files/base.html.js
@@ -1,5 +1,5 @@
 module.exports = `<!doctype html>
-<html>
+<html lang="en">
     <head>    
         {% if stackbit_banner.show_banner %}<link rel="stylesheet" type="text/css" href={{ "assets/css/stackbit-banner.css" | relative_url }}>{% endif %}
         {% include "html_head.html" %}


### PR DESCRIPTION
Partially related to https://github.com/stackbithq/stackbit-theme-universal/pull/1 but it's kinda temporary fix.

Long term solution idea is to extend yaml config with property `lang` and set it `en` as default. So users from other countries can easily configure it for themselves.  