### PR TITLE
[Fix] parseMarkdown startDelimiter

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -107,19 +107,19 @@ function parseMarkdownWithFrontMatter(string) {
     let frontMatterTypes = [
         {
             type: 'yaml',
-            startDelimiter: '---\n',
+            startDelimiter: '---',
             endDelimiter: '\n---',
             parse: (string) => yaml.safeLoad(string, {schema: yaml.JSON_SCHEMA})
         },
         {
             type: 'toml',
-            startDelimiter: '+++\n',
+            startDelimiter: '+++',
             endDelimiter: '\n+++',
             parse: (string) => toml.parse(string)
         },
         {
             type: 'json',
-            startDelimiter: '{\n',
+            startDelimiter: '{',
             endDelimiter: '\n}',
             parse: (string) => JSON.parse(string)
         }


### PR DESCRIPTION
I was not able to build the pages on Windows 10 using `unibit build` or `unibit develop`.
It always outputs `[Unibit] Generating 0 pages...`
I removed the `\n` on each startDelimiter and it now works.
Surprisingly, endDelimiter works fine as is, for example, `\n---`.